### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'release/[0-9]+.[0-9]+.[0-9]+*'
+permissions:
+  contents: read
 jobs:
   test:
     strategy:
@@ -98,6 +100,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-wheels
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Digiratory/FluctuationAnalysisTools/security/code-scanning/5](https://github.com/Digiratory/FluctuationAnalysisTools/security/code-scanning/5)

To fix the issue, explicitly restrict the permissions for the workflow by adding a `permissions` block at the workflow root. This block should grant only the minimum privileges required for the workflow jobs to function. In this workflow, building, testing, and publishing releases and PyPI packages generally require read-only access to repository contents, and write access for creating GitHub releases (via the `softprops/action-gh-release` action).

Based on standard usage, the minimal required permissions are likely `contents: read` (reading repo code for build/test jobs) and `contents: write` (for creating releases or uploads if needed). However, the `softprops/action-gh-release` action generally needs `contents: write`, while most other steps only need read. Thus, a secure starting point is a root `permissions` block with `contents: read`, and for jobs/steps requiring write (if any), an override can be added. But if only the release job needs write, add a job-specific permissions block for that; otherwise, use root scope.

Since the error is flagged at the `deploy` job, set `permissions: contents: write` for the deploy job, and `permissions: contents: read` at the workflow root for the rest. The changes are only to the YAML header region of `.github/workflows/test-and-release.yml`. No extra dependencies need to be installed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
