### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Digiratory/FluctuationAnalysisTools/security/code-scanning/3](https://github.com/Digiratory/FluctuationAnalysisTools/security/code-scanning/3)

To fix the issue, the recommended approach is to add a `permissions` block with the least privileges required by the workflow. In this concrete case, the workflow only interacts with repository contents for checkout and uploading artifacts and does not require write access to contents, issues, pull-requests, or other scopes. The best practice is to add a `permissions` block at the workflow root, which applies to all jobs (unless overridden). This block should specify `contents: read`, which is the minimal privilege needed. The changes are to insert the block after the `name: Run Tests` or just before `jobs:` depending on style (official docs prefer immediately after name and on). No other code or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
