### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/test_ndfnoise_generator.py
+++ b/tests/test_ndfnoise_generator.py
@@ -25,7 +25,6 @@ def get_h_dfa_sliced(arr: np.ndarray) -> np.ndarray:
         h_values = DFA(arr).find_h()
         return h_values
     nx = arr.shape[0]
-    ny = arr.shape[1]
     nz = arr.shape[2]
     results = np.zeros(nx)
 


### PR DESCRIPTION
To fix the problem, remove the unused local variable so that the function defines only variables it actually uses. This preserves existing behavior while satisfying the static analysis rule.

Concretely, in `tests/test_ndfnoise_generator.py`, inside `get_h_dfa_sliced`, eliminate the line `ny = arr.shape[1]`. The function already uses `nx` and `nz` correctly, and `ny` is not needed anywhere. No imports or additional code are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._