### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,6 @@ def test_multiple_crossovers_utils(arguments):
     """
     C_ij, slope_ij, R_ij = arguments
     C_ij_log = list(np.log10(C_ij))
-    y = [0]
     all_values = C_ij_log + slope_ij + R_ij
     tst_s = np.array(
         [


### PR DESCRIPTION
In general, the correct fix for an unused local variable is to either remove it if it is genuinely unnecessary, or use it meaningfully if it represents a missing piece of logic. Here, the variable `y` is neither returned nor passed anywhere and has no impact on the behavior of the test. The simplest fix that preserves existing behavior is to delete the assignment line.

Specifically, in `tests/test_utils.py` within `test_multiple_crossovers_utils`, remove the line `y = [0]` (line 31). No additional imports, methods, or definitions are required. This change eliminates the dead code without altering the test's functionality or its interaction with `analyse_cross_ff` or `cross_fcn_sloped`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._