### PR TITLE
Fix for Wrong number of arguments in a call

### DIFF
--- a/StatTools/analysis/dpcca_as_class.py
+++ b/StatTools/analysis/dpcca_as_class.py
@@ -137,7 +137,7 @@ class DPCCA:
             S_by_workers = np.array_split(S, processes)
 
             if processes == 1:
-                return self._dpcca_worker(s) + s
+                return self._dpcca_worker(s, force_gc=force_gc) + s
 
             if isinstance(self.arr, np.ndarray):
                 chunk = SharedBuffer(self.shape, c_double)


### PR DESCRIPTION
In general, to fix a “too few arguments” error, ensure every call site provides all required positional or keyword arguments expected by the function or method, or adjust the function signature to give defaults. Here, we should not change `_dpcca_worker`’s behavior; instead, we should make the direct call in the `processes == 1` branch pass the same `force_gc` argument that is supplied in the multi‑process branch via `partial`.

Specifically, in `StatTools/analysis/dpcca_as_class.py`, line 140 should be updated from `self._dpcca_worker(s)` to `self._dpcca_worker(s, force_gc=force_gc)` so that both branches of the code path call `_dpcca_worker` consistently with the `force_gc` parameter. No imports or additional definitions are needed, since `force_gc` is already defined and used earlier in the method, and this change preserves existing functionality while removing the risk of a runtime `TypeError`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._