### PR TITLE
fix: add pytest-timeout to test dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
           brew install numpy scipy
           python -m pip install --upgrade pip wheel setuptools
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-timeout
 
       - name: Install dependencies
         if: matrix.os != 'macos-latest'
@@ -49,7 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-timeout
 
       - name: Install FluctuationAnalysisTools
         shell: bash


### PR DESCRIPTION
Add pytest-timeout to the test dependencies in the GitHub Actions workflow to prevent tests from running indefinitely. This change is applied to both macOS and non-macOS environments to ensure consistent test behavior across all platforms.