### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/StatTools/analysis/bma.py
+++ b/StatTools/analysis/bma.py
@@ -67,7 +67,6 @@ def _bma_worker(
     # Using cumulative sums:
     #   sum_{k=t-n+1}^t y[k] = cs[t] - cs[t-n] (for t-n >= 0)
     # NOTE: here t >= n-1, so t-n >= -1; for t-n == -1, sum = cs[t].
-    window_sums = np.empty((n_signals, t_indices.size), dtype=float)
 
     t_indices = np.asarray(t_indices)
 


### PR DESCRIPTION
To fix the problem, remove the redundant first assignment to `window_sums` so that the variable is only initialized once, right before it is actually used. This eliminates dead code and avoids unnecessary memory allocation without changing functionality.

Concretely, in `StatTools/analysis/bma.py`, delete the line that initializes `window_sums` at line 70. The later initialization at line 79 already uses the correct shape and dtype derived from `cs` and `t_indices`. No other code changes, imports, or new definitions are required; all subsequent logic remains the same and continues to operate on the correctly initialized `window_sums`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._